### PR TITLE
add javax dependency

### DIFF
--- a/grpcDemo/pom.xml
+++ b/grpcDemo/pom.xml
@@ -27,6 +27,12 @@
 			<artifactId>grpc-stub</artifactId>
 			<version>1.15.1</version>
 		</dependency>
+		<dependency>
+			<groupId>javax.annotation</groupId>
+			<artifactId>javax.annotation-api</artifactId>
+			<version>1.2</version>
+		</dependency>
+
 	</dependencies>
 
 		<properties>


### PR DESCRIPTION
The dependency is required for compiling with jre > 1.8 or so because gRPC emits this:
```
@javax.annotation.Generated(
    value = "by gRPC proto compiler (version 1.21.0)",
    comments = "Source: fs.proto")
```